### PR TITLE
better json printer

### DIFF
--- a/json.js
+++ b/json.js
@@ -1,4 +1,4 @@
-var stringify = require("json-stringify-safe")
+// var stringify = require("json-stringify-safe")
 
 var send = require("./index")
 var isSendObject = require("./is-send-object")
@@ -15,10 +15,29 @@ function sendJson(req, res, opts, callback) {
         opts.space = "    "
     }
 
+    var tuple = safeStringify(opts.body,
+        opts.replacer || null, opts.space || "");
+
+    if (tuple[0]) {
+        return callback(tuple[0]);
+    }
+
     opts.headers = opts.headers || {}
-    opts.body = stringify(opts.body,
-        opts.replacer || null, opts.space || "")
+    opts.body = tuple[1];
     opts.headers["Content-Type"] = "application/json"
 
     send(req, res, opts, callback)
+}
+
+function safeStringify(obj, replace, space) {
+    var json;
+    var error = null;
+
+    try {
+        json = JSON.stringify(obj, replace, space);
+    } catch (e) {
+        error = e;
+    }
+
+    return [error, json];
 }

--- a/test/integration.js
+++ b/test/integration.js
@@ -29,6 +29,22 @@ function handleRequest(req, res) {
         sendJson(req, res, {
             foo: "bar"
         })
+    } else if (req.url === "/json/shared") {
+        var shared = { foo: "bar" }
+
+        sendJson(req, res, {
+            shared1: shared,
+            shared2: shared
+        })
+    } else if (req.url === "/json/circular") {
+        var circular = {}
+        circular.circular = circular
+
+        sendJson(req, res, circular, function (err) {
+            if (err) {
+                res.end(err.message)
+            }
+        })
     } else if (req.url === "/html") {
         sendHtml(req, res, {
             body: "<div>foo</div>",
@@ -127,6 +143,28 @@ function startTest(request, done) {
             t.equal(body, "OK")
             t.equal(res.statusCode, 200)
             t.equal(res.headers["content-type"], "text/plain; charset=utf-8")
+
+            t.end()
+        })
+    })
+
+    test("shared-json", function (t) {
+        request("/json/shared", function (err, res, body) {
+            var data = JSON.parse(body)
+
+            t.equal(res.statusCode, 200)
+            t.equal(data.shared1.foo, "bar")
+            t.equal(data.shared2.foo, "bar")
+
+            t.end()
+        })
+    })
+
+    test("circular-json", function (t) {
+        request("/json/circular", function (err, res, body) {
+
+            t.equal(res.statusCode, 200)
+            t.equal(res.body, "Converting circular structure to JSON")
 
             t.end()
         })


### PR DESCRIPTION
We ran into an issue with `require('json-stringify-safe')`
    and how its circular json serializing is naive.

In fact when sending an object as JSON we should error
    on a circular structure instead.

cc @sh1mmer @Matt-Esch @dnathe4th
